### PR TITLE
Fix Travis CI build dependency for ruby 1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :development, :test do
   gem 'mime-types', '1.25.1' if RUBY_VERSION == '1.8.7'
   gem 'rest-client', '1.6.9' if RUBY_VERSION == '1.8.7'
   gem 'r10k', '1.5.1' if RUBY_VERSION == '1.8.7'
+  gem 'puppet-blacksmith', '3.1.0' if RUBY_VERSION == '1.8.7'
 
   gem 'bodeco_module_helper', :git => 'https://github.com/bodeco/bodeco_module_helper.git'
   gem 'yard'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,12 @@
 source "https://rubygems.org"
 
 group :development, :test do
+  # pin ruby dependencies to specific gem versions
+  # newer versions not supported by version 1.8.7
+  gem 'mime-types', '1.25.1' if RUBY_VERSION == '1.8.7'
+  gem 'rest-client', '1.6.9' if RUBY_VERSION == '1.8.7'
+  gem 'r10k', '1.5.1' if RUBY_VERSION == '1.8.7'
+
   gem 'bodeco_module_helper', :git => 'https://github.com/bodeco/bodeco_module_helper.git'
   gem 'yard'
   gem 'faraday'


### PR DESCRIPTION
The latest mime-types, rest-client, and r10k gem modules are
not supported by ruby 1.8.7, require at least ruby 1.9.2
This patch is pinning the gems to last supported version.