### PR TITLE
Add Puppet 3.4.x compatibility to path autorequire

### DIFF
--- a/lib/puppet/type/git.rb
+++ b/lib/puppet/type/git.rb
@@ -80,7 +80,17 @@ Puppet::Type.newtype(:git) do
   end
 
   autorequire(:file) do
-    parent = Pathname.new(self[:path]) if self[:path]
+    req = []
+    path = Pathname.new(self[:path])
+    if !path.root?
+      # Start at our parent, to avoid autorequiring ourself
+      parents = path.parent.enum_for(:ascend)
+      if found = parents.find { |p| catalog.resource(:file, p.to_s) }
+        req << found.to_s
+      end
+    end
+
+    req
   end
 
   autorequire(:class) do


### PR DESCRIPTION
The original autorequire failed on 3.4.x, but was working well
on 3.8.x.