### PR TITLE
Fix commit change refresh issue

### DIFF
--- a/lib/puppet/provider/git/default.rb
+++ b/lib/puppet/provider/git/default.rb
@@ -15,9 +15,7 @@ Puppet::Type.type(:git).provide(:git) do
   end
 
   def commit
-    run_cwd{ git('rev-parse', '--verify', resource[:commit]) }
-    head = run_cwd{ git('rev-parse', 'HEAD') }
-    head
+    run_cwd{ git('rev-parse', 'HEAD') }
   end
 
   def commit=(value)

--- a/lib/puppet/provider/git/default.rb
+++ b/lib/puppet/provider/git/default.rb
@@ -16,6 +16,8 @@ Puppet::Type.type(:git).provide(:git) do
 
   def commit
     run_cwd{ git('rev-parse', '--verify', resource[:commit]) }
+    head = run_cwd{ git('rev-parse', 'HEAD') }
+    head
   end
 
   def commit=(value)


### PR DESCRIPTION
When a git resource's commit changed the working tree was not updated. This patch provides an update of ref to new commit value and invoke notification on subscribed resources.

Notice: I've closed the https://github.com/puppet-community/puppet-git_resource/pull/16 pull request, because this patch is a much cleaner and straightforward solution.